### PR TITLE
Ag unmapped variants stderr

### DIFF
--- a/snp_assignment.pl
+++ b/snp_assignment.pl
@@ -220,6 +220,7 @@ sub _GetVepData {
 		    # e.g. "Cannot allocate memory"
 		    # Ensembl suggest to retry a few times to fix the temporary issues
 		    if($repeat_count < 3){
+		        print STDERR "*** RETRYING ***\n\n";
 		        $repeat_count++;
 		        return _GetVepData($id);
 		    }else{

--- a/snp_assignment.pl
+++ b/snp_assignment.pl
@@ -191,7 +191,7 @@ sub _GetVepData {
 	    if($status == 429 && exists $response->{headers}->{'retry-after'}) {
 		    print STDERR "[$current_time_string] HTTP ERROR 429 calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 
@@ -202,7 +202,7 @@ sub _GetVepData {
         } elsif($status == 429) {
             print STDERR "[$current_time_string] HTTP ERROR 429 calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 
@@ -213,7 +213,7 @@ sub _GetVepData {
         } elsif($status == 400){
             print STDERR "[$current_time_string] HTTP ERROR 400 calling VEP with $id - ATTEMPT $repeat_count\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 
 		    # Sometimes the 400 error is returned even though and internal error has happened,
@@ -232,7 +232,7 @@ sub _GetVepData {
         } elsif($status == 504) {
             print STDERR "[$current_time_string] HTTP ERROR 504 calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 
@@ -243,7 +243,7 @@ sub _GetVepData {
         } elsif($status == 503) {
             print STDERR "[$current_time_string] HTTP ERROR 503 calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 
@@ -254,7 +254,7 @@ sub _GetVepData {
  	    }elsif($status == 500){
  	        print STDERR "[$current_time_string] HTTP ERROR 500 calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 
@@ -265,7 +265,7 @@ sub _GetVepData {
  	    }elsif($status == 502){
  	        print STDERR "[$current_time_string] HTTP ERROR 502 calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 
@@ -276,7 +276,7 @@ sub _GetVepData {
  	    }else {
 		    print STDERR "[$current_time_string] HTTP ERROR calling VEP with $id\n";
 		    print STDERR "[STATUS] $response->{status}\n";
-		    print STDERR "[REASON] $response->{reason})\n";
+		    print STDERR "[REASON] $response->{reason}\n";
 		    print STDERR "[CONTENT] $response->{content} \n";
 		    print STDERR "*** RETRYING ***\n\n";
 

--- a/snp_assignment.pl
+++ b/snp_assignment.pl
@@ -221,6 +221,9 @@ sub _GetVepData {
 		    # Ensembl suggest to retry a few times to fix the temporary issues
 		    if($repeat_count < 3){
 		        print STDERR "*** RETRYING ***\n\n";
+		        # Wait random time between 1 and 10 seconds before retrying
+                Time::HiRes::sleep(1.0+rand(9));
+                # after sleeping re-request
 		        $repeat_count++;
 		        return _GetVepData($id);
 		    }else{

--- a/snp_assignment.pl
+++ b/snp_assignment.pl
@@ -87,9 +87,9 @@ while(my $id = <$variant_file>){
 	# e.g. rs876660862, rs869320723
     if(ref($arr_of_hash) ne 'ARRAY'){
         if($arr_of_hash->{error}){
-            print "$id\t$in_ensembl\tNA\tNA\t[VEP ERROR] $arr_of_hash->{error}\tNA\n";
+            print STDERR "$id\t$in_ensembl\tNA\tNA\t[VEP ERROR] $arr_of_hash->{error}\tNA\n";
         }else{
-            print "$id\t$in_ensembl\tNA\tNA\t[VEP Error] Alleles look like an insertion\tNA\n" ;
+            print STDERR "$id\t$in_ensembl\tNA\tNA\t[VEP Error] Alleles look like an insertion\tNA\n" ;
         }
         next;
     }


### PR DESCRIPTION
Small changes to send unmapped variants to stderr instead of stdout, which caused issues in EVA's evidence generation pipeline and some changes to handle better HTTP connection errors.